### PR TITLE
release: Citeasy Lite 홈 화면 UI 1차 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,45 +1,87 @@
-# Miscellaneous
-*.class
-*.log
-*.pyc
-*.swp
-.DS_Store
-.atom/
-.build/
-.buildlog/
-.history
-.svn/
-.swiftpm/
-migrate_working_dir/
-
-# IntelliJ related
-*.iml
-*.ipr
-*.iws
-.idea/
-
-# The .vscode folder contains launch configuration and tasks you configure in
-# VS Code which you may wish to be included in version control, so this line
-# is commented out by default.
-#.vscode/
-
-# Flutter/Dart/Pub related
-**/doc/api/
-**/ios/Flutter/.last_build_id
+# Dart & Flutter 관련
 .dart_tool/
+.packages
+.pub-cache/
 .flutter-plugins
 .flutter-plugins-dependencies
-.pub-cache/
-.pub/
-/build/
+.melos_tool/
+build/
+# For flutter 3.7+
+.dart_tool/package_config.json
 
-# Symbolication related
+# IntelliJ 관련
+*.iml
+.idea/
+*.ipr
+*.iws
+
+# VS Code 관련
+.vscode/
+
+# macOS 관련
+.DS_Store
+*.log
+
+# Android 관련
+android/.gradle/
+android/captures/
+android/.idea/
+android/local.properties
+android/app/release/
+android/app/debug/
+android/app/profile/
+*.keystore
+
+# iOS 관련
+ios/Flutter/.last_build_id
+ios/Pods/
+ios/.symlinks/
+ios/.flutter-plugins
+ios/.flutter-plugins-dependencies
+ios/Runner.xcworkspace/
+ios/Runner.xcodeproj/project.xcworkspace/
+ios/Runner.xcodeproj/xcuserdata/
+
+# Xcode 관련
+*.xcworkspace
+*.xcodeproj/project.xcworkspace/
+*.xcuserstate
+*.xcuserdata
+*.xcuserdatad
+DerivedData/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+*.mode2v3
+*.perspectivev3
+
+# Web 관련
+web/.dart_tool/
+
+# Linux 관련
+linux/flutter/ephemeral/
+linux/CMakeFiles/
+linux/cmake-build-debug/
+linux/cmake-build-release/
+linux/build/
+
+# Windows 관련
+windows/flutter/ephemeral/
+windows/.vs/
+windows/build/
+windows/*.sln
+windows/*.vcxproj*
+windows/*.vcproj*
+windows/*.pdb
+
+# 기타
+*.class
+*.pyc
+*.swp
+*.lock
+*.tmp
+*.bak
+
+# Symbol, obfuscation
 app.*.symbols
-
-# Obfuscation related
 app.*.map.json
-
-# Android Studio will place build artifacts here
-/android/app/debug
-/android/app/profile
-/android/app/release

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'views/home_view.dart';
 
 void main() {
   runApp(const MyApp());
@@ -30,7 +31,8 @@ class MyApp extends StatelessWidget {
         // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    //   home: const MyHomePage(title: 'Flutter Demo Home Page'),
+        home: HomeView(),
     );
   }
 }

--- a/lib/models/citation.dart
+++ b/lib/models/citation.dart
@@ -1,0 +1,13 @@
+class Citation {
+    final String title;
+    final String author;
+    final String year;
+    final String source;
+
+    Citation({
+        required this.title,
+        required this.author,
+        required this.year,
+        required this.source
+    });
+}

--- a/lib/viewmodels/reference_view_model.dart
+++ b/lib/viewmodels/reference_view_model.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class ReferenceItem {
+    final String id;
+    final String title;
+    final String author;
+    final String year;
+
+    ReferenceItem({
+        required this.id,
+        required this.title,
+        required this.author,
+        required this.year,
+    });
+
+    String get citationText => "[$author($year)]";
+}
+
+class ReferenceViewModel extends ChangeNotifier {
+    final List<ReferenceItem> references = [
+        ReferenceItem(id: '1', title: 'Understanding Flutter', author: 'John Doe', year: '2024'),
+        ReferenceItem(id: '2', title: 'Cross-platform UIs', author: 'Jane Smith', year: '2023'),
+    ];
+
+    final Set<String> selectedItemIds = {};
+
+    List<ReferenceItem> get selectedItems =>
+        references.where((item) => selectedItemIds.contains(item.id)).toList();
+
+    void toggleSelection(String id) {
+        if (selectedItemIds.contains(id)) {
+            selectedItemIds.remove(id);
+        } else {
+            selectedItemIds.add(id);
+        }
+        notifyListeners();
+    }
+
+    Future<void> handleCitation(BuildContext context) async {
+        final citations = selectedItems.map((e) => e.citationText).join("\n");
+        await Clipboard.setData(ClipboardData(text: citations));
+
+        ScaffoldMessenger.of(context).showSnackBar(
+            
+            SnackBar(
+                content: Text("인용문이 클립보드에 복사되었습니다."),
+            ),
+        );
+    }
+}

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -1,58 +1,67 @@
 import 'package:flutter/material.dart';
-import '../models/citation.dart';
-import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+
+import '../viewmodels/reference_view_model.dart';
+import '../widgets/top_toolbar.dart';
+import '../widgets/citation_card.dart';
+import '../widgets/preview_panel.dart';
 
 class HomeView extends StatelessWidget {
-    
+    const HomeView({super.key});
 
-  final List<Citation> dummyCitations = [
-    Citation(title: '딥러닝의 이해', author: '홍길동', year: '2023', source: 'DBpia'),
-    Citation(title: 'AI 혁명', author: '이순신', year: '2022', source: 'KISS'),
-  ];
+    @override
+    Widget build(BuildContext context) {
+        return ChangeNotifierProvider(
+            create: (_) => ReferenceViewModel(),
+            child: Scaffold(
+                appBar: AppBar(
+                    title: const Text("Citeasy"),
+                ),
+                body: Column(
+                    children: [
+                        const TopToolbar(),
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('Citeasy Lite'),
-        actions: [
-          IconButton(
-            icon: Icon(Icons.settings),
-            onPressed: () {
-              // TODO: 설정 화면 이동
-            },
-          )
-        ],
-      ),
-      body: ListView.builder(
-        itemCount: dummyCitations.length,
-        itemBuilder: (context, index) {
-          final citation = dummyCitations[index];
-          return Card(
-            margin: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-            child: ListTile(
-              title: Text(citation.title),
-              subtitle: Text('${citation.author} • ${citation.year} • ${citation.source}'),
-              trailing: IconButton(
-                icon: Icon(Icons.copy),
-                onPressed: () {
-                  final formatted = '${citation.author} (${citation.year}). ${citation.title}. ${citation.source}.';
-                  Clipboard.setData(ClipboardData(text: formatted));
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('인용문이 복사되었습니다')),
-                  );
-                },
-              ),
+                        Expanded(
+                            child: Consumer<ReferenceViewModel>(
+                                builder: (context, viewModel, _) {
+                                    return ListView.builder(
+                                        itemCount: viewModel.references.length,
+                                        itemBuilder: (context, index) {
+                                            final item = viewModel.references[index];
+                                            final isSelected = viewModel.selectedItemIds.contains(item.id);
+                                            return CitationCard(
+                                                item: item,
+                                                isSelected: isSelected,
+                                                onToggle: () => viewModel.toggleSelection(item.id),
+                                            );
+                                        },
+                                    );
+                                },
+                            ),
+                        ),
+
+                        Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                            child: Consumer<ReferenceViewModel>(
+                                builder: (context, viewModel, _) {
+                                    return SizedBox(
+                                        width: double.infinity,
+                                        child: ElevatedButton.icon(
+                                            onPressed: viewModel.selectedItems.isEmpty
+                                                ? null
+                                                : () => viewModel.handleCitation(context),
+                                            icon: const Icon(Icons.copy),
+                                            label: const Text("참고문헌 생성"),
+                                        ),
+                                    );
+                                },
+                            ),
+                        ),
+
+                        const PreviewPanel(),
+                    ],
+                ),
             ),
-          );
-        },
-      ),
-      floatingActionButton: FloatingActionButton(
-        child: Icon(Icons.add),
-        onPressed: () {
-          // TODO: AddCitationView로 이동
-        },
-      ),
-    );
-  }
+        );
+    }
 }

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import '../models/citation.dart';
+import 'package:flutter/services.dart';
+
+class HomeView extends StatelessWidget {
+    
+
+  final List<Citation> dummyCitations = [
+    Citation(title: '딥러닝의 이해', author: '홍길동', year: '2023', source: 'DBpia'),
+    Citation(title: 'AI 혁명', author: '이순신', year: '2022', source: 'KISS'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Citeasy Lite'),
+        actions: [
+          IconButton(
+            icon: Icon(Icons.settings),
+            onPressed: () {
+              // TODO: 설정 화면 이동
+            },
+          )
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: dummyCitations.length,
+        itemBuilder: (context, index) {
+          final citation = dummyCitations[index];
+          return Card(
+            margin: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: ListTile(
+              title: Text(citation.title),
+              subtitle: Text('${citation.author} • ${citation.year} • ${citation.source}'),
+              trailing: IconButton(
+                icon: Icon(Icons.copy),
+                onPressed: () {
+                  final formatted = '${citation.author} (${citation.year}). ${citation.title}. ${citation.source}.';
+                  Clipboard.setData(ClipboardData(text: formatted));
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('인용문이 복사되었습니다')),
+                  );
+                },
+              ),
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        child: Icon(Icons.add),
+        onPressed: () {
+          // TODO: AddCitationView로 이동
+        },
+      ),
+    );
+  }
+}

--- a/lib/widgets/citation_card.dart
+++ b/lib/widgets/citation_card.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import '../../viewmodels/reference_view_model.dart';
+
+class CitationCard extends StatelessWidget {
+    final ReferenceItem item;
+    final bool isSelected;
+    final VoidCallback onToggle;
+
+    const CitationCard({
+        super.key,
+        required this.item,
+        required this.isSelected,
+        required this.onToggle,
+    });
+
+    @override
+    Widget build(BuildContext context) {
+        return GestureDetector(
+            onTap: onToggle,
+            child: Container(
+                margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                    color: isSelected
+                        ? Theme.of(context).colorScheme.primary.withOpacity(0.2)
+                        : Theme.of(context).colorScheme.surface,
+                    border: Border.all(
+                        color: isSelected
+                            ? Theme.of(context).colorScheme.primary
+                            : Colors.grey.shade300,
+                    ),
+                    borderRadius: BorderRadius.circular(12),
+                ),
+                child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                        Text(
+                            item.title,
+                            style: const TextStyle(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 16,
+                            ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                            "${item.author} · ${item.year}",
+                            style: const TextStyle(
+                                fontSize: 14,
+                                color: Colors.grey,
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+        );
+    }
+}

--- a/lib/widgets/preview_panel.dart
+++ b/lib/widgets/preview_panel.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../viewmodels/reference_view_model.dart';
+
+class PreviewPanel extends StatelessWidget {
+    const PreviewPanel({super.key});
+
+    @override
+    Widget build(BuildContext context) {
+        final viewModel = context.watch<ReferenceViewModel>();
+        final selected = viewModel.selectedItems;
+
+        final previewText = selected.isNotEmpty
+            ? selected.map((e) => e.citationText).join("\n")
+            : "선택된 참고문헌이 없습니다.";
+
+        return Container(
+            padding: const EdgeInsets.all(16),
+            width: double.infinity,
+            decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surfaceVariant,
+                border: Border(
+                    top: BorderSide(
+                        color: Theme.of(context).dividerColor,
+                    ),
+                ),
+            ),
+            child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                    const Text(
+                        "미리보기",
+                        style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14,
+                        ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                        previewText,
+                        style: const TextStyle(fontSize: 15),
+                    ),
+                ],
+            ),
+        );
+    }
+}

--- a/lib/widgets/side_menu.dart
+++ b/lib/widgets/side_menu.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class SideMenu extends StatelessWidget {
+	const SideMenu({super.key});
+
+	@override
+	Widget build(BuildContext context) {
+		return Container(
+			width: 240, // 좌측 메뉴 너비
+			color: Theme.of(context).colorScheme.surfaceVariant,
+			child: Column(
+				crossAxisAlignment: CrossAxisAlignment.start,
+				children: [
+					const SizedBox(height: 24),
+					_buildMenuItem(context, Icons.folder_copy, '내 서재', onTap: () {
+						// TODO: 내 서재 화면으로 이동
+					}),
+					_buildMenuItem(context, Icons.format_quote, '인용 양식', onTap: () {
+						// TODO: 인용 양식 화면으로 이동
+					}),
+					_buildMenuItem(context, Icons.settings, '설정', onTap: () {
+						// TODO: 설정 화면으로 이동
+					}),
+					const Spacer(),
+					Padding(
+						padding: const EdgeInsets.all(16.0),
+						child: Text(
+							'v1.0.0',
+							style: Theme.of(context).textTheme.labelSmall?.copyWith(color: Colors.grey),
+						),
+					),
+				],
+			),
+		);
+	}
+
+	Widget _buildMenuItem(BuildContext context, IconData icon, String title, {VoidCallback? onTap}) {
+		return InkWell(
+			onTap: onTap,
+			child: Padding(
+				padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+				child: Row(
+					children: [
+						Icon(icon, size: 20, color: Theme.of(context).colorScheme.onSurface),
+						const SizedBox(width: 12),
+						Text(
+							title,
+							style: Theme.of(context).textTheme.bodyMedium,
+						),
+					],
+				),
+			),
+		);
+	}
+}

--- a/lib/widgets/top_toolbar.dart
+++ b/lib/widgets/top_toolbar.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../viewmodels/reference_view_model.dart';
+
+class TopToolbar extends StatelessWidget {
+    const TopToolbar({super.key});
+
+    @override
+    Widget build(BuildContext context) {
+        final vm = context.watch<ReferenceViewModel>();
+
+        return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+                children: [
+                    const Text(
+                        "정렬 기준:",
+                        style: TextStyle(fontSize: 14),
+                    ),
+                    const SizedBox(width: 8),
+                    DropdownButton<String>(
+                        value: "최신순", // 실제 옵션 없음
+                        items: const [
+                            DropdownMenuItem(value: "최신순", child: Text("최신순")),
+                            DropdownMenuItem(value: "오래된순", child: Text("오래된순")),
+                        ],
+                        onChanged: (value) {
+                            // 정렬 기능 미구현이므로 비워둠
+                        },
+                    ),
+                    const Spacer(),
+                    const Text("사용 중인 양식:"),
+                    const SizedBox(width: 8),
+                    ElevatedButton(
+                        onPressed: () {
+                            // 향후 스타일 변경 처리
+                        },
+                        child: const Text("APA 7th"),
+                    ),
+                    const SizedBox(width: 12),
+                    ToggleButtons(
+                        isSelected: const [true, false],
+                        onPressed: (index) {
+                            // 언어 토글 (국문/영문) 기능 미구현
+                        },
+                        children: const [
+                            Padding(
+                                padding: EdgeInsets.symmetric(horizontal: 12),
+                                child: Text("국문"),
+                            ),
+                            Padding(
+                                padding: EdgeInsets.symmetric(horizontal: 12),
+                                child: Text("영문"),
+                            ),
+                        ],
+                    )
+                ],
+            ),
+        );
+    }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -131,6 +131,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -139,6 +147,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: "489024f942069c2920c844ee18bb3d467c69e48955a4f32d1677f71be103e310"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.4"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  provider: ^6.0.5  # ← 이 줄 추가
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Citeasy Lite 프로젝트의 홈 화면 UI 구조를 1차적으로 구현 완료하여 main 브랜치로 병합합니다.

### 포함 내용
- 홈 화면 기본 UI 구성 완료
  - 정렬 기준/인용 양식/언어 선택 툴바
  - 참고문헌 카드 목록
  - 인용문 미리보기 영역
  - 인용하기 버튼
- 공통 위젯 분리 및 구조 정비
- 프로젝트 초기 구조 설정
- macOS 및 Android 에뮬레이터 환경에서 기본 동작 테스트 완료